### PR TITLE
[Skeleton] PBI-001 Domain Layer Implementation

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -42,6 +42,8 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // put your Multiplatform dependencies here
+            implementation(libs.kotlinx.datetime)
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${libs.versions.kotlinx.coroutines.get()}")
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/shared/src/commonMain/kotlin/com/example/playground/domain/model/TodoItem.kt
+++ b/shared/src/commonMain/kotlin/com/example/playground/domain/model/TodoItem.kt
@@ -1,0 +1,31 @@
+package com.example.playground.domain.model
+
+import kotlinx.datetime.Instant
+
+/**
+ * TODOアイテムのドメインモデル
+ * 不変オブジェクトとして設計され、アプリケーション全体で使用される
+ */
+data class TodoItem(
+    val id: Long = 0,
+    val title: String,
+    val description: String = "",
+    val isCompleted: Boolean = false,
+    val createdAt: Instant,
+    val completedAt: Instant? = null
+) {
+    /**
+     * タイトルが有効かどうかをチェック
+     */
+    fun isValidTitle(): Boolean = title.isNotBlank() && title.length <= MAX_TITLE_LENGTH
+
+    /**
+     * 説明が有効かどうかをチェック
+     */
+    fun isValidDescription(): Boolean = description.length <= MAX_DESCRIPTION_LENGTH
+
+    companion object {
+        const val MAX_TITLE_LENGTH = 100
+        const val MAX_DESCRIPTION_LENGTH = 500
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/playground/domain/repository/TodoRepository.kt
+++ b/shared/src/commonMain/kotlin/com/example/playground/domain/repository/TodoRepository.kt
@@ -1,0 +1,53 @@
+package com.example.playground.domain.repository
+
+import com.example.playground.domain.model.TodoItem
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * TODOアイテムのデータアクセス用Repository interface
+ * Clean Architectureの依存関係逆転の原則に従い、Domain層でインターフェースを定義
+ * Data層で実装される
+ */
+interface TodoRepository {
+
+    /**
+     * 全TODOアイテムを取得
+     * @return 全TODOアイテムのリスト（Result型でエラーハンドリング）
+     */
+    suspend fun getAllTodos(): Result<List<TodoItem>>
+
+    /**
+     * 全TODOアイテムをFlowで監視
+     * リアルタイムでデータ変更を通知
+     * @return TODOアイテムリストのFlow
+     */
+    fun observeAllTodos(): Flow<List<TodoItem>>
+
+    /**
+     * 指定IDのTODOアイテムを取得
+     * @param id TODOアイテムのID
+     * @return TODOアイテム（存在しない場合はエラー）
+     */
+    suspend fun getTodoById(id: Long): Result<TodoItem>
+
+    /**
+     * 新しいTODOアイテムを作成
+     * @param todo 作成するTODOアイテム（IDは自動生成される）
+     * @return 作成されたTODOアイテム（IDが設定済み）
+     */
+    suspend fun createTodo(todo: TodoItem): Result<TodoItem>
+
+    /**
+     * 既存のTODOアイテムを更新
+     * @param todo 更新するTODOアイテム
+     * @return 更新されたTODOアイテム
+     */
+    suspend fun updateTodo(todo: TodoItem): Result<TodoItem>
+
+    /**
+     * TODOアイテムを削除
+     * @param id 削除するTODOアイテムのID
+     * @return 削除成功時はUnit、失敗時はエラー
+     */
+    suspend fun deleteTodo(id: Long): Result<Unit>
+}

--- a/shared/src/commonMain/kotlin/com/example/playground/domain/usecase/CreateTodoUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/example/playground/domain/usecase/CreateTodoUseCase.kt
@@ -1,0 +1,47 @@
+package com.example.playground.domain.usecase
+
+import com.example.playground.domain.model.TodoItem
+import com.example.playground.domain.repository.TodoRepository
+import kotlinx.datetime.Clock
+
+/**
+ * TODO作成UseCase
+ * TODO作成時のビジネスロジックとバリデーションを担当
+ */
+class CreateTodoUseCase(
+    private val repository: TodoRepository
+) {
+
+    /**
+     * 新しいTODOアイテムを作成
+     * @param title TODOのタイトル
+     * @param description TODOの説明（オプション）
+     * @return 作成されたTODOアイテム
+     */
+    suspend operator fun invoke(
+        title: String,
+        description: String = ""
+    ): Result<TodoItem> {
+        // バリデーション
+        if (title.isBlank()) {
+            return Result.failure(IllegalArgumentException("タイトルは必須です"))
+        }
+
+        if (title.length > TodoItem.MAX_TITLE_LENGTH) {
+            return Result.failure(IllegalArgumentException("タイトルは${TodoItem.MAX_TITLE_LENGTH}文字以内で入力してください"))
+        }
+
+        if (description.length > TodoItem.MAX_DESCRIPTION_LENGTH) {
+            return Result.failure(IllegalArgumentException("説明は${TodoItem.MAX_DESCRIPTION_LENGTH}文字以内で入力してください"))
+        }
+
+        // TODOアイテム作成
+        val todoItem = TodoItem(
+            title = title.trim(),
+            description = description.trim(),
+            createdAt = Clock.System.now()
+        )
+
+        return repository.createTodo(todoItem)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/playground/domain/usecase/DeleteTodoUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/example/playground/domain/usecase/DeleteTodoUseCase.kt
@@ -1,0 +1,25 @@
+package com.example.playground.domain.usecase
+
+import com.example.playground.domain.repository.TodoRepository
+
+/**
+ * TODO削除UseCase
+ * TODO削除時のビジネスロジックを担当
+ */
+class DeleteTodoUseCase(
+    private val repository: TodoRepository
+) {
+
+    /**
+     * TODOアイテムを削除
+     * @param todoId 削除するTODOアイテムのID
+     * @return 削除結果
+     */
+    suspend operator fun invoke(todoId: Long): Result<Unit> {
+        // ビジネスロジック：存在確認を行ってから削除
+        return repository.getTodoById(todoId)
+            .mapCatching { existingTodo ->
+                repository.deleteTodo(existingTodo.id).getOrThrow()
+            }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/playground/domain/usecase/GetTodosUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/example/playground/domain/usecase/GetTodosUseCase.kt
@@ -1,0 +1,34 @@
+package com.example.playground.domain.usecase
+
+import com.example.playground.domain.model.TodoItem
+import com.example.playground.domain.repository.TodoRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * TODO一覧取得UseCase
+ * ビジネスロジックを含む場合は、このクラス内で処理を行う
+ */
+class GetTodosUseCase(
+    private val repository: TodoRepository
+) {
+
+    /**
+     * 全TODOアイテムを一度だけ取得
+     * @return TODO一覧取得結果
+     */
+    suspend operator fun invoke(): Result<List<TodoItem>> {
+        return repository.getAllTodos()
+            .mapCatching { todos ->
+                // ビジネスロジック：作成日時でソート
+                todos.sortedBy { it.createdAt }
+            }
+    }
+
+    /**
+     * TODOアイテムをリアルタイムで監視
+     * @return TODOアイテムリストのFlow（作成日時順）
+     */
+    fun observe(): Flow<List<TodoItem>> {
+        return repository.observeAllTodos()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/playground/domain/usecase/UpdateTodoUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/example/playground/domain/usecase/UpdateTodoUseCase.kt
@@ -1,0 +1,49 @@
+package com.example.playground.domain.usecase
+
+import com.example.playground.domain.model.TodoItem
+import com.example.playground.domain.repository.TodoRepository
+import kotlinx.datetime.Clock
+
+/**
+ * TODO更新UseCase
+ * TODO更新時のビジネスロジックとバリデーションを担当
+ */
+class UpdateTodoUseCase(
+    private val repository: TodoRepository
+) {
+
+    /**
+     * TODOアイテムを更新
+     * @param updatedTodo 更新するTODOアイテム
+     * @return 更新されたTODOアイテム
+     */
+    suspend operator fun invoke(updatedTodo: TodoItem): Result<TodoItem> {
+        // バリデーション
+        if (!updatedTodo.isValidTitle()) {
+            return Result.failure(IllegalArgumentException("タイトルが無効です"))
+        }
+
+        if (!updatedTodo.isValidDescription()) {
+            return Result.failure(IllegalArgumentException("説明が無効です"))
+        }
+
+        return repository.updateTodo(updatedTodo)
+    }
+
+    /**
+     * TODOの完了状態を切り替え
+     * @param todoId 対象TODOのID
+     * @param isCompleted 完了状態
+     * @return 更新されたTODOアイテム
+     */
+    suspend fun toggleCompletion(todoId: Long, isCompleted: Boolean): Result<TodoItem> {
+        return repository.getTodoById(todoId)
+            .mapCatching { existingTodo ->
+                val updatedTodo = existingTodo.copy(
+                    isCompleted = isCompleted,
+                    completedAt = if (isCompleted) Clock.System.now() else null
+                )
+                repository.updateTodo(updatedTodo).getOrThrow()
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- SK-001: Domain Layer Skeleton実装完了
- Clean Architecture パターン適用
- ドメインモデル、Repository interface、UseCase interfaces実装
- kotlinx-datetime、kotlinx-coroutines-core依存関係追加

## 実装内容
### ドメインモデル
- `TodoItem` data class: 不変オブジェクトとして設計
- バリデーションメソッド内包（タイトル・説明文字数制限）

### Repository Interface  
- `TodoRepository`: Clean ArchitectureのRepository pattern適用
- 全CRUD操作をサポート
- Flow によるリアクティブデータ監視
- Result型による統一エラーハンドリング

### UseCase Classes
- `GetTodosUseCase`: TODO一覧取得・リアクティブ監視
- `CreateTodoUseCase`: TODO作成時バリデーションとビジネスロジック
- `UpdateTodoUseCase`: TODO更新・完了状態切り替え機能  
- `DeleteTodoUseCase`: 削除前存在確認ロジック

## 品質確認
- ✅ ビルド成功確認済み
- ✅ 依存関係逆転の原則準拠
- ✅ インターフェース完全性確認
- ✅ ドメインルール明確性確保

## 変更行数
約240行（新規追加）

## 次のステップ
SK-001完了後、SK-002（Data Layer Skeleton）の実装に進行予定

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>